### PR TITLE
Fix new Clippy 1.49 lints

### DIFF
--- a/crates/rslint_core/src/file.rs
+++ b/crates/rslint_core/src/file.rs
@@ -72,7 +72,7 @@ impl File {
     }
 
     // TODO: Needs to work correctly for \u2028, \u2029, and \r line endings
-    pub fn line_starts<'a>(source: &'a str) -> impl Iterator<Item = usize> + 'a {
+    pub fn line_starts(source: &str) -> impl Iterator<Item = usize> + '_ {
         std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
     }
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -234,6 +234,6 @@ fn n_attached_trivias<'a>(
 fn linebreak_count(text: &str) -> usize {
     text.matches('\n').count()
         + text.matches('\r').count()
-        + text.matches("\u{2028}").count()
-        + text.matches("\u{2029}").count()
+        + text.matches('\u{2028}').count()
+        + text.matches('\u{2029}').count()
 }

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -92,14 +92,18 @@ pub struct Parser<'t> {
 impl<'t> Parser<'t> {
     /// Make a new parser
     pub fn new(tokens: TokenSource<'t>, file_id: usize, syntax: Syntax) -> Parser<'t> {
-        let mut state = ParserState::default();
         // TODO(RDambrosio016): Does TypeScript imply Module/Strict?
-        state.is_module = syntax.file_kind == FileKind::Module;
-        state.strict = if syntax.file_kind == FileKind::Module {
+        let strict = if syntax.file_kind == FileKind::Module {
             Some(StrictMode::Module)
         } else {
             None
         };
+        let state = ParserState {
+            is_module: syntax.file_kind == FileKind::Module,
+            strict,
+            ..ParserState::default()
+        };
+
         Parser {
             file_id,
             tokens,

--- a/crates/rslint_parser/src/util.rs
+++ b/crates/rslint_parser/src/util.rs
@@ -383,8 +383,8 @@ pub fn contains_js_linebreak(string: impl AsRef<str>) -> bool {
     let text = string.as_ref();
     text.contains('\n')
         || text.contains('\r')
-        || text.contains("\u{2028}")
-        || text.contains("\u{2029}")
+        || text.contains('\u{2028}')
+        || text.contains('\u{2029}')
 }
 
 /// Check whether a string contains a valid js whitespace character

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -79,9 +79,11 @@ pub fn run(query: Option<&str>) {
 
     let mut counter = 0usize;
     let mut create_column = |name: colored::ColoredString| {
-        let mut column = Column::default();
-        column.header = name.to_string();
-        column.align = ascii_table::Align::Center;
+        let column = Column {
+            header: name.to_string(),
+            align: ascii_table::Align::Center,
+            ..Column::default()
+        };
         table.columns.insert(counter, column);
         counter += 1;
     };


### PR DESCRIPTION
Other lint failures are blocked by https://github.com/GREsau/schemars/pull/65, and there is some dead code still in `lsp/util`.