### PR TITLE
Use a cache on CI and simplify some jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,19 +77,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux, windows, macos]
-
         include:
-          - name: linux
-            os: ubuntu-latest
+          - os: ubuntu-latest
             artifact_name: rslint_cli
             asset_name: rslint_cli-linux
-          - name: windows
-            os: windows-latest
+          - os: windows-latest
             artifact_name: rslint_cli.exe
             asset_name: rslint_cli-windows
-          - name: macos
-            os: macos-latest
+          - os: macos-latest
             artifact_name: rslint_cli
             asset_name: rslint_cli-macos
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,19 +19,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { rust: stable, os: ubuntu-latest }
-          - { rust: nightly, os: ubuntu-latest }
-          - { rust: stable, os: windows-latest }
-          - { rust: nightly, os: windows-latest }
-          - { rust: stable, os: macos-latest }
-          - { rust: nightly, os: macos-latest }
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v1
       - run: cargo test --verbose --workspace --all-features
 
   clippy:
@@ -46,6 +42,7 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v1
       - run: cargo clippy --workspace --all-targets --verbose --all-features
 
   rustfmt:
@@ -62,6 +59,8 @@ jobs:
   check-rustdoc-links:
     name: Check doc links
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
 
     steps:
       - uses: actions/checkout@v2
@@ -69,10 +68,9 @@ jobs:
         with:
           rust-version: nightly
       # Check every crate in the workspace
-      - run: |
-          for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
-            cargo rustdoc -p "$package" --all-features --lib -- -D warnings
-          done
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo doc --workspace --all-features --document-private-items --no-deps
+
   deploy:
     name: Deploy for ${{ matrix.os }}
     if: startsWith(github.ref, 'refs/tags')

--- a/crates/rslint_config/src/lib.rs
+++ b/crates/rslint_config/src/lib.rs
@@ -1,5 +1,8 @@
 //! Configuration file support.
 
+// FIXME: Workaround for https://github.com/GREsau/schemars/pull/65
+#![allow(clippy::field_reassign_with_default)]
+
 mod de;
 use dirs_next::config_dir;
 use rslint_core::{get_group_rules_by_name, CstRule, CstRuleStore, Diagnostic, RuleLevel};

--- a/crates/rslint_core/src/lib.rs
+++ b/crates/rslint_core/src/lib.rs
@@ -26,6 +26,9 @@
 //! ⚠️ note however that many rules rely on checking tokens or the root and running on single nodes
 //! may yield incorrect results, you should only do this if you know about the rule's implementation.
 
+// FIXME: Workaround for https://github.com/GREsau/schemars/pull/65
+#![allow(clippy::field_reassign_with_default)]
+
 mod file;
 mod rule;
 mod store;


### PR DESCRIPTION
Uses the `Swatinem/rust-cache` action to cache dependencies, and uses
`RUSTDOCFLAGS` instead of calling rustdoc via a shell loop.