### PR TITLE
Fix: use correct token length for SHREQ token

### DIFF
--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -1071,7 +1071,7 @@ impl<'src> Lexer<'src> {
                     }
                 } else if self.bytes.get(self.cur + 1).copied() == Some(b'=') {
                     self.advance(2);
-                    tok!(SHREQ, 2)
+                    tok!(SHREQ, 3)
                 } else {
                     tok!(>)
                 }


### PR DESCRIPTION
Currently, the token length of a SHREQ token was 2, which caused
code like this:

```
x >>= 1;
```

panic and also caused one panic in test262.
This is now fixed and the correct token length is used

Now there's only one panic left in test262 suite.
The last panic is deeply inside the TS Parser, which caused me so much pain that I won't be able to fix it