### PR TITLE
Docs: update repository URL

### DIFF
--- a/crates/rslint_cli/Cargo.toml
+++ b/crates/rslint_cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RSLint developers"]
 edition = "2018"
 description = "CLI crate and glue for the rslint project"
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [[bin]]
 name = "rslint"

--- a/crates/rslint_cli/src/panic_hook.rs
+++ b/crates/rslint_cli/src/panic_hook.rs
@@ -14,7 +14,7 @@ pub fn panic_hook(info: &PanicInfo) {
 
     write("The linter panicked unexpectedly. This is a bug.\n");
 
-    write("We would appreciate a bug report: https://github.com/RDambrosio016/RSLint/issues/new?labels=ILE%2C+bug&template=internal-linter-error.md\n");
+    write("We would appreciate a bug report: https://github.com/rslint/rslint/issues/new?labels=ILE%2C+bug&template=internal-linter-error.md\n");
 
     write("Please include the following info: \n");
 

--- a/crates/rslint_config/Cargo.toml
+++ b/crates/rslint_config/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RSLint developers"]
 edition = "2018"
 description = "The rslint specific config format."
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [dependencies]
 rslint_errors = { path = "../rslint_errors" }

--- a/crates/rslint_core/Cargo.toml
+++ b/crates/rslint_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RSLint developers"]
 edition = "2018"
 description = "The core linter housing all of the rules for the rslint project"
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [lib]
 bench = false

--- a/crates/rslint_lexer/Cargo.toml
+++ b/crates/rslint_lexer/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.3"
 authors = ["RSLint developers"]
 description = "An extremely fast ECMAScript lexer made for the rslint project"
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [dependencies]
 rslint_errors = { path = "../rslint_errors", version = "0.1.0" }

--- a/crates/rslint_lsp/Cargo.toml
+++ b/crates/rslint_lsp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 authors = ["Darin Morrison <darinmorrison@users.noreply.github.com>"]
 description = "A language server implementation for rslint."
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [[bin]]
 name = "rslint-lsp"

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.1"
 authors = ["RDambrosio016 <rdambrosio016@gmail.com>"]
 license = "MIT"
 description = "An extremely fast ECMAScript parser made for the rslint project"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [dependencies]
 rslint_errors = { path = "../rslint_errors", version = "0.1.0" }

--- a/crates/rslint_regex/Cargo.toml
+++ b/crates/rslint_regex/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RSLint developers"]
 edition = "2018"
 description = "RegEx parser for the ECMAScript definition"
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [dependencies]
 bitflags = "1.2.1"

--- a/crates/rslint_syntax/Cargo.toml
+++ b/crates/rslint_syntax/Cargo.toml
@@ -5,6 +5,6 @@ version = "0.1.3"
 authors = ["RSLint developers"]
 description = "SyntaxKind and common rowan definitions for rslint_parser"
 license = "MIT"
-repository = "https://github.com/RDambrosio016/RSLint"
+repository = "https://github.com/rslint/rslint"
 
 [dependencies]

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -6,11 +6,11 @@
   "author": {
     "name": "Darin Morrison",
     "email": "darinmorrison@users.noreply.github.com",
-    "url": "https://github.com/RDambrosio016/RSLint"
+    "url": "https://github.com/rslint/rslint"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/RDambrosio016/RSLint.git"
+    "url": "https://github.com/rslint/rslint.git"
   },
   "displayName": "vscode-rslint",
   "publisher": "darinmorrison",

--- a/website/docs/.vuepress/config.js
+++ b/website/docs/.vuepress/config.js
@@ -31,8 +31,8 @@ module.exports = {
         link: "https://docs.rs/rslint_core"
       },
       {
-        text: "Github",
-        link: "https://github.com/RDambrosio016/RSLint"
+        text: "GitHub",
+        link: "https://github.com/rslint/rslint"
       }
     ],
     sidebar: {

--- a/website/docs/dev/README.md
+++ b/website/docs/dev/README.md
@@ -17,4 +17,4 @@ may not understand some of the more in depth areas, here are some resources to l
 
 ## Contributing
 
-The best way to learn is to contribute! You can find issues to work on by looking at [issues](https://github.com/RDambrosio016/RSLint/issues) with the `E-Easy` and `E-Mentor` labels. `E-Mentor` issues have explanations as to how to fix/implement the topic of the issue to guide you through.
+The best way to learn is to contribute! You can find issues to work on by looking at [issues](https://github.com/rslint/rslint/issues) with the `E-Easy` and `E-Mentor` labels. `E-Mentor` issues have explanations as to how to fix/implement the topic of the issue to guide you through.

--- a/website/docs/dev/docgen.md
+++ b/website/docs/dev/docgen.md
@@ -1,12 +1,12 @@
 # Docgen
 
 Documentation for the rules folder is not manually written, documentation is written as rust doc comments
-in source files (in the lint declaration). And a [docgen script](https://github.com/RDambrosio016/RSLint/blob/master/xtask/src/docgen/mod.rs) is used to generate the user facing docs.
+in source files (in the lint declaration). And a [docgen script](https://github.com/rslint/rslint/blob/master/xtask/src/docgen/mod.rs) is used to generate the user facing docs.
 The docgen script allows us to make rustdoc documentation, as well as user facing documentation automatically.
 
 Docgen goes through a few steps to collect docs:
 
-- The script crawls the [groups directory](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_core/src/groups), for every group it will:
+- The script crawls the [groups directory](https://github.com/rslint/rslint/tree/master/crates/rslint_core/src/groups), for every group it will:
   - Collect the group name by looking at the `group!` invocation in `mod.rs`
   - For each rule file it will then:
   - Collect the `declare_lint!` invocation, from this it grabs the main documentation, replacing all `ignore` code blocks with `js`.

--- a/website/docs/dev/lexing.md
+++ b/website/docs/dev/lexing.md
@@ -1,6 +1,6 @@
 # Lexing
 
-Lexing is the first step which occurs in parsing ECMAScript. The job of a lexer is to take raw source code and turn it into abstract tokens which the parser then works on. RSLint uses its own lexer implementation in [`rslint_lexer`](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_lexer/src).
+Lexing is the first step which occurs in parsing ECMAScript. The job of a lexer is to take raw source code and turn it into abstract tokens which the parser then works on. RSLint uses its own lexer implementation in [`rslint_lexer`](https://github.com/rslint/rslint/tree/master/crates/rslint_lexer/src).
 
 For example, code such as `var a = 2 + 2;` will be broken down into:
 
@@ -19,7 +19,7 @@ NUMBER
 SEMICOLON
 ```
 
-As you probably noticed, whitespace is included in the tokens for reasons we will cover later. Although, the parser does not work on tokens with whitespace and comments (whitespace and comments are sometimes called trivia), there is an intermediate structure called the [`TokenSource`](https://github.com/RDambrosio016/RSLint/blob/master/crates/rslint_parser/src/token_source.rs) which manages the raw tokens and turning them into tokens the parser can use.
+As you probably noticed, whitespace is included in the tokens for reasons we will cover later. Although, the parser does not work on tokens with whitespace and comments (whitespace and comments are sometimes called trivia), there is an intermediate structure called the [`TokenSource`](https://github.com/rslint/rslint/blob/master/crates/rslint_parser/src/token_source.rs) which manages the raw tokens and turning them into tokens the parser can use.
 
 ## Losslessness
 
@@ -39,4 +39,4 @@ pub struct Token {
 - All possible token kinds
 - All possible AST node kinds
 
-This central concept of a single enum is important because RSLint's syntax tree is deeply intertwined with the underlying tokens as you will see later on. The [`SyntaxKind`](https://github.com/RDambrosio016/RSLint/blob/master/crates/rslint_syntax/src/generated.rs) enum is not written manually, it is generated from [a file](https://github.com/RDambrosio016/RSLint/blob/master/xtask/src/ast.rs) which also houses AST definitions which generate AST structs as you will see later.
+This central concept of a single enum is important because RSLint's syntax tree is deeply intertwined with the underlying tokens as you will see later on. The [`SyntaxKind`](https://github.com/rslint/rslint/blob/master/crates/rslint_syntax/src/generated.rs) enum is not written manually, it is generated from [a file](https://github.com/rslint/rslint/blob/master/xtask/src/ast.rs) which also houses AST definitions which generate AST structs as you will see later.

--- a/website/docs/dev/parsing.md
+++ b/website/docs/dev/parsing.md
@@ -39,6 +39,6 @@ Error recovery is a central concept of RSLint, and it allows us to lint incorrec
 
 ## Quick links
 
-- [where the actual JS parsing logic is](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_parser/src/syntax)
-- [where the AST logic is](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_parser/src/ast)
-- [where the central Parser structure is](https://github.com/RDambrosio016/RSLint/blob/master/crates/rslint_parser/src/parser.rs)
+- [where the actual JS parsing logic is](https://github.com/rslint/rslint/tree/master/crates/rslint_parser/src/syntax)
+- [where the AST logic is](https://github.com/rslint/rslint/tree/master/crates/rslint_parser/src/ast)
+- [where the central Parser structure is](https://github.com/rslint/rslint/blob/master/crates/rslint_parser/src/parser.rs)

--- a/website/docs/dev/rules.md
+++ b/website/docs/dev/rules.md
@@ -15,7 +15,7 @@ no_extra_semi::NoExtraSemi
 
 Don't worry if you get errors, theyll be fixed soon.
 
-RSLint defines a [rule_prelude](https://github.com/RDambrosio016/RSLint/blob/master/crates/rslint_core/src/rule_prelude.rs) module, which contains commonly used
+RSLint defines a [rule_prelude](https://github.com/rslint/rslint/blob/master/crates/rslint_core/src/rule_prelude.rs) module, which contains commonly used
 items by rules, which saves a ton of painful imports.
 
 the prelude includes a `declare_lint` macro, this macro is a way of easily declaring a new rule, it is also used by

--- a/website/docs/guide/README.md
+++ b/website/docs/guide/README.md
@@ -8,7 +8,7 @@ RSLint is a tool for finding and fixing problematic productions in ECMAScript/Ja
 enforce style and good practices. RSLint is similar to ESLint with some major differences:
 
 - RSLint is written in Rust and therefore very fast.
-- RSLint uses a [`custom parser`](https://github.com/RDambrosio016/RSLint/tree/master/crates/rslint_parser/src) to parse JavaScript.
+- RSLint uses a [`custom parser`](https://github.com/rslint/rslint/tree/master/crates/rslint_parser/src) to parse JavaScript.
 - RSLint uses a CST (concrete syntax tree) as well as untyped nodes to evaluate patterns in code.
 - RSLint can lint any code no matter how wrong it is.
 - RSLint groups rules into distinct groups.
@@ -18,8 +18,8 @@ enforce style and good practices. RSLint is similar to ESLint with some major di
 You must have cargo installed on your machine, then git clone the repository, and either build the binary and run it, or use cargo run directly.
 
 ```sh
-git clone https://github.com/RDambrosio016/RSLint.git
-cd RSLint
+git clone https://github.com/rslint/rslint.git
+cd rslint
 cargo run --release -- ./glob/pattern.js
 ```
 
@@ -30,7 +30,7 @@ cargo install rslint_cli
 rslint ./glob/pattern.js
 ```
 
-If you do not have rust installed you can find prebuilt binaries for every release [here](https://github.com/RDambrosio016/RSLint/releases).
+If you do not have rust installed you can find prebuilt binaries for every release [here](https://github.com/rslint/rslint/releases).
 
 # Running in VSC
 

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RDambrosio016/RSLint.git"
+    "url": "git+https://github.com/rslint/rslint.git"
   },
   "keywords": [
     "JavaScript",
@@ -18,9 +18,9 @@
   "author": "RSLint developers",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/RDambrosio016/RSLint/issues"
+    "url": "https://github.com/rslint/rslint/issues"
   },
-  "homepage": "https://github.com/RDambrosio016/RSLint#readme",
+  "homepage": "https://github.com/rslint/rslint#readme",
   "devDependencies": {
     "vuepress": "^1.7.1",
     "vuepress-plugin-container": "^2.1.5"


### PR DESCRIPTION
Noticed that `rslint` repo lives into `rslint` organization so I'm opening this Pull Request in order to update all URLs that refer to this repo.

Actions performed:
- Replacing `github.com/RDambrosio016/RSLint` by `github.com/rslint/rslint`;
- Rename `Github` into `GitHub`;

Hope you'll find this useful.
Thank you!