### PR TITLE
Docs: fix name of `allowed` config field

### DIFF
--- a/website/docs/guide/config.md
+++ b/website/docs/guide/config.md
@@ -7,7 +7,7 @@ RSLint is fully configurable, you can configure the linter through a `rslintrc.t
 You can configure what rules the linter runs using the `rules` field.
 The `rules` field can take 4 keys, these are:
 
-- `allow`: an array of strings of rules which are explicitly allowed and will not be run.
+- `allowed`: an array of strings of rules which are explicitly allowed and will not be run.
 - `errors`: an object where each key is a rule name, and the value is the rule's configuration options (or `{}` if no config). These rules will be treated as errors.
 - `warnings`: same as `errors` but the rules will be treated as warnings.
 - `groups`: an array of strings where each string is the name of a [rule group](../rules). All of the rules of each group will be treated as errors.
@@ -20,7 +20,7 @@ For instance:
 
 ```toml
 [rules]
-allow = ["no-empty"]
+allowed = ["no-empty"]
 groups = ["errors"]
 
 [rules.errors]
@@ -33,7 +33,7 @@ no-empty = {}
 ```json
 {
   "rules": {
-    "allow": ["no-empty"],
+    "allowed": ["no-empty"],
     "groups": ["errors"],
     "errors": {
       "no-empty": { "disallowEmptyFunctions": true }
@@ -45,7 +45,7 @@ no-empty = {}
 }
 ```
 
-In this case `no-empty` would not be run, because `allow` always takes precedence. If allow was not there then the `no-empty` in `rules.errors` would
+In this case `no-empty` would not be run, because `allowed` always takes precedence. If `allowed` was not there then the `no-empty` in `rules.errors` would
 be run. if that was not there then the configuration in `rules.warnings` would be used. if that was not there then the rule would be run at error level because it is included in `errors`.
 
 The linter will warn you if a rule config is being ignored because of precedence.
@@ -72,14 +72,14 @@ Enabling all rules in the `errors` group but allowing `no-empty`:
 ```toml
 [rules]
 groups = ["errors"]
-allow = ["no-empty"]
+allowed = ["no-empty"]
 ```
 
 ```json
 {
   "rules": {
     "groups": ["errors"],
-    "allow": ["no-empty"]
+    "allowed": ["no-empty"]
   }
 }
 ```


### PR DESCRIPTION
It looks like it’s always been `allowed`? I might be missing something.