### PR TITLE
Fix object computed getter/setter parsing

### DIFF
--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -1025,3 +1025,26 @@ fn at_token() {
         IDENT:3
     }
 }
+
+#[test]
+fn object_expr_getter() {
+    assert_lex! {
+        "({ get [foo]() {} })",
+        L_PAREN:1
+        L_CURLY:1
+        WHITESPACE:1
+        IDENT:3
+        WHITESPACE:1
+        L_BRACK:1
+        IDENT:3
+        R_BRACK:1
+        L_PAREN:1
+        R_PAREN:1
+        WHITESPACE:1
+        L_CURLY:1
+        R_CURLY:1
+        WHITESPACE:1
+        R_CURLY:1
+        R_PAREN:1
+    }
+}

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -1090,7 +1090,6 @@ pub fn method(
     let m = marker.into().unwrap_or_else(|| p.start());
     let old = p.state.to_owned();
     p.state.in_function = true;
-    // FIXME: handle get* which is a property + a generator
     let complete = match p.cur() {
         T!['('] | T![<] => {
             args_body(p);

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -1183,11 +1183,14 @@ pub fn object_property(p: &mut Parser) -> Option<CompletedMarker> {
         // }
         //
         // let b = {
-        //  set foo(bar) {
+        //  set [foo](bar) {
         //     return 5;
         //  }
         // }
-        T![ident] if (p.cur_src() == "get" || p.cur_src() == "set") && p.nth_at(1, T![ident]) => {
+        T![ident]
+            if (p.cur_src() == "get" || p.cur_src() == "set")
+                && (p.nth_at(1, T![ident]) || p.nth_at(1, T!['['])) =>
+        {
             method(p, None, None)
         }
         // test object_expr_async_method

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.js
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.js
@@ -1,0 +1,5 @@
+let a = {
+  get [foo]() {
+    return foo;
+  }
+}

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -1,0 +1,40 @@
+MODULE@0..48
+  VAR_DECL@0..47
+    IDENT@0..3 "let"
+    WHITESPACE@3..4 " "
+    DECLARATOR@4..47
+      SINGLE_PATTERN@4..5
+        NAME@4..5
+          IDENT@4..5 "a"
+      WHITESPACE@5..6 " "
+      EQ@6..7 "="
+      WHITESPACE@7..8 " "
+      OBJECT_EXPR@8..47
+        L_CURLY@8..9 "{"
+        WHITESPACE@9..12 "\n  "
+        GETTER@12..45
+          GET_KW@12..15 "get"
+          WHITESPACE@15..16 " "
+          COMPUTED_PROPERTY_NAME@16..21
+            L_BRACK@16..17 "["
+            NAME_REF@17..20
+              IDENT@17..20 "foo"
+            R_BRACK@20..21 "]"
+          PARAMETER_LIST@21..23
+            L_PAREN@21..22 "("
+            R_PAREN@22..23 ")"
+          WHITESPACE@23..24 " "
+          BLOCK_STMT@24..45
+            L_CURLY@24..25 "{"
+            WHITESPACE@25..30 "\n    "
+            RETURN_STMT@30..41
+              RETURN_KW@30..36 "return"
+              WHITESPACE@36..37 " "
+              NAME_REF@37..40
+                IDENT@37..40 "foo"
+              SEMICOLON@40..41 ";"
+            WHITESPACE@41..44 "\n  "
+            R_CURLY@44..45 "}"
+        WHITESPACE@45..46 "\n"
+        R_CURLY@46..47 "}"
+  WHITESPACE@47..48 "\n"


### PR DESCRIPTION
There are other places (like in decl.rs) where it just checks `p.nth(1) != T!['(']` but I think thats a little too forgiving and using that broke a _lot_ of test262 tests.